### PR TITLE
Fix deprecated withOpacity

### DIFF
--- a/lib/screens/autos/autos_screen.dart
+++ b/lib/screens/autos/autos_screen.dart
@@ -67,7 +67,7 @@ class _AutosScreenState extends State<AutosScreen> {
             begin: Alignment.topCenter,
             end: Alignment.bottomCenter,
             colors: [
-              AppColors.primary.withOpacity(0.02),
+              AppColors.primary.withValues(alpha: 0.02),
               AppColors.backgroundLight,
             ],
           ),
@@ -89,7 +89,7 @@ class _AutosScreenState extends State<AutosScreen> {
         decoration: BoxDecoration(
           boxShadow: [
             BoxShadow(
-              color: AppColors.primary.withOpacity(0.1),
+              color: AppColors.primary.withValues(alpha: 0.1),
               blurRadius: 8,
               offset: const Offset(0, -2),
             ),

--- a/lib/screens/autos/inventario/imagenes_tab_widget.dart
+++ b/lib/screens/autos/inventario/imagenes_tab_widget.dart
@@ -265,7 +265,7 @@ class ImagenesTabWidget extends ConsumerWidget {
                   right: 8,
                   child: Container(
                     decoration: BoxDecoration(
-                      color: Colors.black.withOpacity(0.7),
+                      color: Colors.black.withValues(alpha: 0.7),
                       borderRadius: BorderRadius.circular(20),
                     ),
                     child: IconButton(
@@ -479,7 +479,7 @@ class ImagenesTabWidget extends ConsumerWidget {
                 onPressed: () => Navigator.pop(context),
                 icon: const Icon(Icons.close, color: Colors.white, size: 32),
                 style: IconButton.styleFrom(
-                  backgroundColor: Colors.black.withOpacity(0.5),
+                  backgroundColor: Colors.black.withValues(alpha: 0.5),
                 ),
               ),
             ),
@@ -493,7 +493,7 @@ class ImagenesTabWidget extends ConsumerWidget {
                 child: Container(
                   padding: const EdgeInsets.all(16),
                   decoration: BoxDecoration(
-                    color: Colors.black.withOpacity(0.7),
+                    color: Colors.black.withValues(alpha: 0.7),
                     borderRadius: BorderRadius.circular(8),
                   ),
                   child: Text(

--- a/lib/screens/autos/inventario/inventario_detalle_nave_screen.dart
+++ b/lib/screens/autos/inventario/inventario_detalle_nave_screen.dart
@@ -148,7 +148,7 @@ class _InventarioDetalleNaveScreenState
         color: const Color(0xFF003B5C),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.1),
+            color: Colors.black.withValues(alpha: 0.1),
             blurRadius: 4,
             offset: const Offset(0, 2),
           ),
@@ -193,7 +193,7 @@ class _InventarioDetalleNaveScreenState
           Container(
             padding: const EdgeInsets.all(16),
             decoration: BoxDecoration(
-              color: Colors.white.withOpacity(0.1),
+              color: Colors.white.withValues(alpha: 0.1),
               borderRadius: BorderRadius.circular(12),
             ),
             child: Row(
@@ -235,7 +235,7 @@ class _InventarioDetalleNaveScreenState
       children: [
         Text(
           label,
-          style: TextStyle(color: Colors.white.withOpacity(0.8), fontSize: 12),
+          style: TextStyle(color: Colors.white.withValues(alpha: 0.8), fontSize: 12),
         ),
         Text(
           value.isNotEmpty ? value : 'N/A',
@@ -264,7 +264,7 @@ class _InventarioDetalleNaveScreenState
         ),
         Text(
           label,
-          style: TextStyle(color: Colors.white.withOpacity(0.8), fontSize: 10),
+          style: TextStyle(color: Colors.white.withValues(alpha: 0.8), fontSize: 10),
           textAlign: TextAlign.center,
         ),
       ],
@@ -297,7 +297,7 @@ class _InventarioDetalleNaveScreenState
             leading: Container(
               padding: const EdgeInsets.all(8),
               decoration: BoxDecoration(
-                color: const Color(0xFF003B5C).withOpacity(0.1),
+                color: const Color(0xFF003B5C).withValues(alpha: 0.1),
                 borderRadius: BorderRadius.circular(8),
               ),
               child: const Icon(
@@ -592,7 +592,7 @@ class _InventarioDetalleNaveScreenState
             child: Container(
               padding: const EdgeInsets.all(6),
               decoration: BoxDecoration(
-                color: const Color(0xFF003B5C).withOpacity(0.1),
+                color: const Color(0xFF003B5C).withValues(alpha: 0.1),
                 borderRadius: BorderRadius.circular(4),
               ),
               child: const Icon(
@@ -733,7 +733,7 @@ class _InventarioDetalleNaveScreenState
         borderRadius: BorderRadius.circular(8),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.1),
+            color: Colors.black.withValues(alpha: 0.1),
             blurRadius: 10,
             offset: const Offset(0, 2),
           ),

--- a/lib/screens/autos/inventario/inventario_detalle_screen.dart
+++ b/lib/screens/autos/inventario/inventario_detalle_screen.dart
@@ -100,7 +100,7 @@ class _InventarioDetalleScreenState
         bottom: TabBar(
           controller: _tabController,
           labelColor: Colors.white,
-          unselectedLabelColor: Colors.white.withOpacity(0.6),
+          unselectedLabelColor: Colors.white.withValues(alpha: 0.6),
           indicatorColor: Colors.white,
           indicatorWeight: 3,
           tabs: [
@@ -168,7 +168,7 @@ class _InventarioDetalleScreenState
           Container(
             padding: const EdgeInsets.all(12),
             decoration: BoxDecoration(
-              color: const Color(0xFF003B5C).withOpacity(0.1),
+              color: const Color(0xFF003B5C).withValues(alpha: 0.1),
               borderRadius: BorderRadius.circular(12),
             ),
             child: Text(

--- a/lib/widgets/pedeteo/queue_side_widget.dart
+++ b/lib/widgets/pedeteo/queue_side_widget.dart
@@ -138,9 +138,9 @@ class QueueContent extends ConsumerWidget {
       child: Container(
         padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
         decoration: BoxDecoration(
-          color: color.withOpacity(0.1),
+          color: color.withValues(alpha: 0.1),
           borderRadius: BorderRadius.circular(8),
-          border: Border.all(color: color.withOpacity(0.3)),
+          border: Border.all(color: color.withValues(alpha: 0.3)),
         ),
         child: Column(
           children: [
@@ -154,7 +154,7 @@ class QueueContent extends ConsumerWidget {
             ),
             Text(
               label,
-              style: TextStyle(fontSize: 11, color: color.withOpacity(0.8)),
+              style: TextStyle(fontSize: 11, color: color.withValues(alpha: 0.8)),
             ),
           ],
         ),
@@ -457,7 +457,7 @@ class QueueRecordTile extends StatelessWidget {
     }
 
     return CircleAvatar(
-      backgroundColor: color.withOpacity(0.15),
+      backgroundColor: color.withValues(alpha: 0.15),
       child: Icon(icon, color: color, size: 20),
     );
   }

--- a/lib/widgets/vin_scanner_screen.dart
+++ b/lib/widgets/vin_scanner_screen.dart
@@ -194,7 +194,7 @@ class _VinScannerScreenState extends State<VinScannerScreen> {
             child: Container(
               padding: const EdgeInsets.all(16),
               decoration: BoxDecoration(
-                color: Colors.black.withOpacity(0.7),
+                color: Colors.black.withValues(alpha: 0.7),
                 borderRadius: BorderRadius.circular(12),
               ),
               child: Column(
@@ -231,7 +231,7 @@ class _VinScannerScreenState extends State<VinScannerScreen> {
           // Loading indicator cuando está procesando
           if (_isProcessing)
             Container(
-              color: Colors.black.withOpacity(0.5),
+              color: Colors.black.withValues(alpha: 0.5),
               child: const Center(
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.center,
@@ -259,7 +259,7 @@ class ScannerOverlayPainter extends CustomPainter {
   @override
   void paint(Canvas canvas, Size size) {
     final paint = Paint()
-      ..color = Colors.black.withOpacity(0.5)
+      ..color = Colors.black.withValues(alpha: 0.5)
       ..style = PaintingStyle.fill;
 
     final scanArea = Rect.fromCenter(


### PR DESCRIPTION
## Summary
- use `withValues(alpha:)` across the app instead of deprecated `withOpacity`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f704470483309ecf897ef434c6e0