### PR TITLE
Fix context and connectivity usage

### DIFF
--- a/lib/screens/autos/contenedores/contenedor_form.dart
+++ b/lib/screens/autos/contenedores/contenedor_form.dart
@@ -580,16 +580,17 @@ class _ContenedorFormState extends ConsumerState<ContenedorForm> {
             fotoContenedorVacioPath: _fotoContenedorVacioPath,
           );
 
-      if (success && mounted) {
+      if (!mounted) return;
+
+      if (success) {
         Navigator.of(context).pop();
         _showSuccess(context, 'Contenedor creado exitosamente');
-      } else if (mounted) {
+      } else {
         _showError(context, 'Error al crear el contenedor');
       }
     } catch (e) {
-      if (mounted) {
-        _showError(context, 'Error: $e');
-      }
+      if (!mounted) return;
+      _showError(context, 'Error: $e');
     } finally {
       if (mounted) {
         setState(() => _isLoading = false);

--- a/lib/screens/autos/contenedores/contenedores_tab.dart
+++ b/lib/screens/autos/contenedores/contenedores_tab.dart
@@ -684,20 +684,19 @@ class _ContenedoresTabState extends ConsumerState<ContenedoresTab> {
                   .read(contenedorProvider.notifier)
                   .deleteContenedor(contenedor.id);
 
-              if (mounted) {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Text(
-                      success
-                          ? 'Contenedor eliminado correctamente'
-                          : 'Error al eliminar contenedor',
-                    ),
-                    backgroundColor: success
-                        ? AppColors.success
-                        : AppColors.error,
+              if (!mounted) return;
+
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text(
+                    success
+                        ? 'Contenedor eliminado correctamente'
+                        : 'Error al eliminar contenedor',
                   ),
-                );
-              }
+                  backgroundColor:
+                      success ? AppColors.success : AppColors.error,
+                ),
+              );
             },
             child: const Text(
               'Eliminar',

--- a/lib/services/background_queue_service.dart
+++ b/lib/services/background_queue_service.dart
@@ -121,7 +121,7 @@ class BackgroundQueueService {
   Future<bool> _hasInternetConnection() async {
     try {
       final connectivityResult = await Connectivity().checkConnectivity();
-      return connectivityResult != ConnectivityResult.none;
+      return !connectivityResult.contains(ConnectivityResult.none);
     } catch (e) {
       print('Error verificando conectividad: $e');
       return false;

--- a/lib/services/queue_service.dart
+++ b/lib/services/queue_service.dart
@@ -187,7 +187,7 @@ class QueueService {
     try {
       // Verificar conectividad
       final connectivity = await Connectivity().checkConnectivity();
-      if (connectivity == ConnectivityResult.none) {
+      if (connectivity.contains(ConnectivityResult.none)) {
         debugPrint('Sin conectividad, skipping queue processing');
         return;
       }
@@ -261,8 +261,8 @@ class QueueService {
   }
 
   void _listenToConnectivity() {
-    Connectivity().onConnectivityChanged.listen((result) {
-      if (result != ConnectivityResult.none &&
+    Connectivity().onConnectivityChanged.listen((results) {
+      if (!results.contains(ConnectivityResult.none) &&
           _currentSnapshot.pendingCount > 0) {
         debugPrint('Connectivity restored, processing queue');
         _tryImmediateProcessing();


### PR DESCRIPTION
## Summary
- fix BuildContext usage after async gaps in contenedor forms
- fix BuildContext usage after async gap when deleting contenedores
- handle list-based connectivity results

## Testing
- `flutter analyze` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866f9b39f0483308201ea08abd8e89b